### PR TITLE
Add package.json and Dependabot npm tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "janbernloehr-github-io",
+  "private": true,
+  "description": "Tracks versions of self-hosted frontend assets",
+  "dependencies": {
+    "@fontsource/inter": "5.2.8",
+    "@fontsource/mulish": "5.2.8",
+    "bootstrap": "5.3.8",
+    "mathjax": "3.2.2"
+  }
+}


### PR DESCRIPTION
Adds a `package.json` declaring the self-hosted frontend assets as npm dependencies, and extends `.github/dependabot.yml` with an npm ecosystem entry alongside the existing bundler config.

Dependabot will now open PRs when new versions of these packages are published:
- `bootstrap`
- `mathjax`
- `@fontsource/inter`
- `@fontsource/mulish`

**Note:** Dependabot PRs will update `package.json`/`package-lock.json` only. The actual asset files in `assets/` still need to be re-downloaded manually (or via a workflow) when bumping versions.