### PR TITLE
Improve Impressum and privacy policy

### DIFF
--- a/_includes/themes/bootstrap-5/default.html
+++ b/_includes/themes/bootstrap-5/default.html
@@ -60,7 +60,7 @@
         <a href="https://jekyllbootstrap.com" target="_blank" title="The Definitive Jekyll Blogging Framework">Jekyll Bootstrap</a> and
         <a href="https://getbootstrap.com" target="_blank">Bootstrap</a> |
         <a href="{{ BASE_PATH }}/impressum">Impressum</a> | 
-        <a href="{{ BASE_PATH }}/privacy">Privacy</a>
+        <a href="{{ BASE_PATH }}/privacy">Datenschutz</a>
       </p>
     </div>
   </footer>

--- a/impressum.md
+++ b/impressum.md
@@ -10,12 +10,11 @@ Jan Bernlöhr<br />
 Salamanderplatz 3<br />
 70806 Kornwestheim
 
-#### Vertreten durch
-Jan Bernlöhr
-
 #### Kontakt
-Telefon: 07154-8079956<br />
 E-Mail: jan@bernloehrs.de
+
+#### Streitschlichtung
+Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: [https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/). Zur Teilnahme an einem Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle bin ich nicht verpflichtet und nicht bereit.
 
 ### Haftungsausschluss: 
 

--- a/privacy.md
+++ b/privacy.md
@@ -1,201 +1,63 @@
 ---
 layout: page
-title: Privacy Policy of janbernloehr.de
+title: Datenschutzerklärung
 ---
 {% include JB/setup %}
 
-This Website collects some Personal Data from its Users.
+*Stand: März 2026*
 
-### Owner and Data Controller
-Jan Bernlöhr<br /> 
+### Verantwortlicher
+
+Jan Bernlöhr<br />
 Salamanderplatz 3<br />
 70806 Kornwestheim<br />
-Owner contact email: jan@bernloehrs.de
+E-Mail: jan@bernloehrs.de
 
 <hr />
 
-### Types of Data collected
+### Welche Daten werden erfasst?
 
-Among the types of Personal Data that this Website collects, by itself or through third parties, there are: Cookies and Usage Data.
-
-Complete details on each type of Personal Data collected are provided in the dedicated sections of this privacy policy or by specific explanation texts displayed prior to the Data collection.
-Personal Data may be freely provided by the User, or, in case of Usage Data, collected automatically when using this Website.
-
-Unless specified otherwise, all Data requested by this Website is mandatory and failure to provide this Data may make it impossible for this Website to provide its services. In cases where this Website specifically states that some Data is not mandatory, Users are free not to communicate this Data without consequences to the availability or the functioning of the Service.
-
-Users who are uncertain about which Personal Data is mandatory are welcome to contact the Owner.
-
-Any use of Cookies – or of other tracking tools – by this Website or by the owners of third-party services used by this Website serves the purpose of providing the Service required by the User, in addition to any other purposes described in the present document and in the Cookie Policy, if available.
-
-Users are responsible for any third-party Personal Data obtained, published or shared through this Website and confirm that they have the third party's consent to provide the Data to the Owner.
+Diese Website erhebt selbst keine personenbezogenen Daten und setzt keine eigenen Cookies. Beim Aufruf der Website werden jedoch durch die eingesetzten Drittanbieter (Hosting, CDN) technische Daten wie IP-Adressen und Zugriffszeitpunkte serverseitig verarbeitet. Dies ist für den Betrieb der Website technisch notwendig.
 
 <hr />
 
-### Mode and place of processing the Data
+### Drittanbieter
 
-#### Methods of processing
+#### GitHub Pages (GitHub, Inc.)
 
-The Owner takes appropriate security measures to prevent unauthorized access, disclosure, modification, or unauthorized destruction of the Data.
+Diese Website wird über GitHub Pages gehostet. Beim Aufruf der Website werden Verbindungsdaten (u. a. IP-Adresse, Zeitpunkt des Zugriffs, aufgerufene URL) an GitHub übermittelt und in Server-Logs gespeichert.
 
-The Data processing is carried out using computers and/or IT enabled tools, following organizational procedures and modes strictly related to the purposes indicated. In addition to the Owner, in some cases, the Data may be accessible to certain types of persons in charge, involved with the operation of this Website (administration, sales, marketing, legal, system administration) or external parties (such as third-party technical service providers, mail carriers, hosting providers, IT companies, communications agencies) appointed, if necessary, as Data Processors by the Owner. The updated list of these parties may be requested from the Owner at any time.
+Anbieter: GitHub, Inc., 88 Colin P Kelly Jr St, San Francisco, CA 94107, USA<br />
+Rechtsgrundlage für die Übermittlung in die USA: Standardvertragsklauseln (Art. 46 Abs. 2 lit. c DSGVO)<br />
+Datenschutzerklärung: [https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
 
-#### Legal basis of processing
+#### Cloudflare (Cloudflare, Inc.)
 
-The Owner may process Personal Data relating to Users if one of the following applies:
-- Users have given their consent for one or more specific purposes. Note: Under some legislations the Owner may be allowed to process Personal Data until the User objects to such processing (“opt-out”), without having to rely on consent or any other of the following legal bases. This, however, does not apply, whenever the processing of Personal Data is subject to European data protection law;
-- provision of Data is necessary for the performance of an agreement with the User and/or for any pre-contractual obligations thereof;
-- processing is necessary for compliance with a legal obligation to which the Owner is subject;
-- processing is related to a task that is carried out in the public interest or in the exercise of official authority vested in the Owner;
-- processing is necessary for the purposes of the legitimate interests pursued by the Owner or by a third party.
+Der Datenverkehr dieser Website wird über Cloudflare geleitet. Cloudflare verarbeitet dabei Verbindungsdaten (u. a. IP-Adresse) zum Zweck der Auslieferung und des Schutzes der Website.
 
-In any case, the Owner will gladly help to clarify the specific legal basis that applies to the processing, and in particular whether the provision of Personal Data is a statutory or contractual requirement, or a requirement necessary to enter into a contract.
-
-#### Place
-The Data is processed at the Owner's operating offices and in any other places where the parties involved in the processing are located.
-
-Depending on the User's location, data transfers may involve transferring the User's Data to a country other than their own. To find out more about the place of processing of such transferred Data, Users can check the section containing details about the processing of Personal Data.
-
-Users are also entitled to learn about the legal basis of Data transfers to a country outside the European Union or to any international organization governed by public international law or set up by two or more countries, such as the UN, and about the security measures taken by the Owner to safeguard their Data.
-
-If any such transfer takes place, Users can find out more by checking the relevant sections of this document or inquire with the Owner using the information provided in the contact section.
-
-#### Retention time
-Personal Data shall be processed and stored for as long as required by the purpose they have been collected for.
-
-Therefore:
-- Personal Data collected for purposes related to the performance of a contract between the Owner and the User shall be retained until such contract has been fully performed.
-- Personal Data collected for the purposes of the Owner’s legitimate interests shall be retained as long as needed to fulfill such purposes. Users may find specific information regarding the legitimate interests pursued by the Owner within the relevant sections of this document or by contacting the Owner.
-
-The Owner may be allowed to retain Personal Data for a longer period whenever the User has given consent to such processing, as long as such consent is not withdrawn. Furthermore, the Owner may be obliged to retain Personal Data for a longer period whenever required to do so for the performance of a legal obligation or upon order of an authority.
-
-Once the retention period expires, Personal Data shall be deleted. Therefore, the right to access, the right to erasure, the right to rectification and the right to data portability cannot be enforced after expiration of the retention period.
+Anbieter: Cloudflare, Inc., 101 Townsend St, San Francisco, CA 94107, USA<br />
+Rechtsgrundlage für die Übermittlung in die USA: Standardvertragsklauseln (Art. 46 Abs. 2 lit. c DSGVO)<br />
+Datenschutzerklärung: [https://www.cloudflare.com/privacypolicy/](https://www.cloudflare.com/privacypolicy/)
 
 <hr />
 
-### The purposes of processing
+### Rechtsgrundlage
 
-The Data concerning the User is collected to allow the Owner to provide its Services, as well as for the following purposes: Traffic optimization and distribution and Hosting and backend infrastructure.
-
-Users can find further detailed information about such purposes of processing and about the specific Personal Data used for each purpose in the respective sections of this document.
+Die Verarbeitung der oben genannten Verbindungsdaten durch die Drittanbieter erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse). Das berechtigte Interesse liegt im technisch einwandfreien und sicheren Betrieb dieser Website.
 
 <hr />
 
-### Detailed information on the processing of Personal Data
+### Ihre Rechte
 
-Personal Data is collected for the following purposes and using the following services:
+Sie haben gegenüber dem Verantwortlichen folgende Rechte hinsichtlich Ihrer personenbezogenen Daten:
 
-#### Hosting and backend infrastructure
+- **Recht auf Auskunft** (Art. 15 DSGVO)
+- **Recht auf Berichtigung** (Art. 16 DSGVO)
+- **Recht auf Löschung** (Art. 17 DSGVO)
+- **Recht auf Einschränkung der Verarbeitung** (Art. 18 DSGVO)
+- **Recht auf Datenübertragbarkeit** (Art. 20 DSGVO)
+- **Recht auf Widerspruch** (Art. 21 DSGVO)
 
-This type of service has the purpose of hosting Data and files that enable this Website to run and be distributed as well as to provide a ready-made infrastructure to run specific features or parts of this Website. Some of these services work through geographically distributed servers, making it difficult to determine the actual location where the Personal Data are stored.
+Zur Ausübung Ihrer Rechte wenden Sie sich bitte an die oben genannte Kontaktadresse. Anfragen werden kostenlos und innerhalb eines Monats beantwortet.
 
-##### GitHub Pages (GitHub Inc.)
-GitHub Pages is a hosting service provided by GitHub, Inc.
-
-Personal Data collected: various types of Data as specified in the privacy policy of the service.
-
-Place of processing: United States – [Privacy Policy](https://help.github.com/articles/github-privacy-policy). Privacy Shield participant.
-
-#### Traffic optimization and distribution
-
-This type of service allows this Website to distribute their content using servers located across different countries and to optimize their performance.
-
-Which Personal Data are processed depends on the characteristics and the way these services are implemented. Their function is to filter communications between this Website and the User's browser.
-
-Considering the widespread distribution of this system, it is difficult to determine the locations to which the contents that may contain Personal Information User are transferred.
-
-##### CloudFlare (Cloudflare)
-CloudFlare is a traffic optimization and distribution service provided by CloudFlare Inc.
-
-The way CloudFlare is integrated means that it filters all the traffic through this Website, i.e., communication between this Website and the User's browser, while also allowing analytical data from this Website to be collected.
-
-Personal Data collected: Cookies and various types of Data as specified in the privacy policy of the service.
-
-Place of processing: United States – [Privacy Policy](https://www.cloudflare.com/security-policy/).
-
-<hr />
-
-### The rights of Users
-Users may exercise certain rights regarding their Data processed by the Owner.
-
-In particular, Users have the right to do the following:
-- __Withdraw their consent at any time.__ Users have the right to withdraw consent where they have previously given their consent to the processing of their Personal Data.
-- __Object to processing of their Data.__ Users have the right to object to the processing of their Data if the processing is carried out on a legal basis other than consent. Further details are provided in the dedicated section below.
-- __Access their Data.__ Users have the right to learn if Data is being processed by the Owner, obtain disclosure regarding certain aspects of the processing and obtain a copy of the Data undergoing processing.
-- __Verify and seek rectification.__ Users have the right to verify the accuracy of their Data and ask for it to be updated or corrected.
-- __Restrict the processing of their Data.__ Users have the right, under certain circumstances, to restrict the processing of their Data. In this case, the Owner will not process their Data for any purpose other than storing it.
-- __Have their Personal Data deleted or otherwise removed.__ Users have the right, under certain circumstances, to obtain the erasure of their Data from the Owner.
-- __Receive their Data and have it transferred to another controller.__ Users have the right to receive their Data in a structured, commonly used and machine readable format and, if technically feasible, to have it transmitted to another controller without any hindrance. This provision is applicable provided that the Data is processed by automated means and that the processing is based on the User's consent, on a contract which the User is part of or on pre-contractual obligations thereof.
-- __Lodge a complaint.__ Users have the right to bring a claim before their competent data protection authority.
-
-#### Details about the right to object to processing
-Where Personal Data is processed for a public interest, in the exercise of an official authority vested in the Owner or for the purposes of the legitimate interests pursued by the Owner, Users may object to such processing by providing a ground related to their particular situation to justify the objection.
-
-Users must know that, however, should their Personal Data be processed for direct marketing purposes, they can object to that processing at any time without providing any justification. To learn, whether the Owner is processing Personal Data for direct marketing purposes, Users may refer to the relevant sections of this document.
-
-#### How to exercise these rights
-Any requests to exercise User rights can be directed to the Owner through the contact details provided in this document. These requests can be exercised free of charge and will be addressed by the Owner as early as possible and always within one month.
-
-<hr />
-
-### Additional information about Data collection and processing
-#### Legal action
-The User's Personal Data may be used for legal purposes by the Owner in Court or in the stages leading to possible legal action arising from improper use of this Website or the related Services.
-
-The User declares to be aware that the Owner may be required to reveal personal data upon request of public authorities.
-
-#### Additional information about User's Personal Data
-In addition to the information contained in this privacy policy, this Website may provide the User with additional and contextual information concerning particular Services or the collection and processing of Personal Data upon request.
-
-#### System logs and maintenance
-For operation and maintenance purposes, this Website and any third-party services may collect files that record interaction with this Website (System logs) use other Personal Data (such as the IP Address) for this purpose.
-
-#### Information not contained in this policy
-More details concerning the collection or processing of Personal Data may be requested from the Owner at any time. Please see the contact information at the beginning of this document.
-
-#### How “Do Not Track” requests are handled
-This Website does not support “Do Not Track” requests.
-To determine whether any of the third-party services it uses honor the “Do Not Track” requests, please read their privacy policies.
-
-#### Changes to this privacy policy
-The Owner reserves the right to make changes to this privacy policy at any time by giving notice to its Users on this page and possibly within this Website and/or - as far as technically and legally feasible - sending a notice to Users via any contact information available to the Owner. It is strongly recommended to check this page often, referring to the date of the last modification listed at the bottom. 
-
-Should the changes affect processing activities performed on the basis of the User’s consent, the Owner shall collect new consent from the User, where required.
-
-<hr />
-
-### Definitions and legal references
-
-#### Personal Data (or Data)
-Any information that directly, indirectly, or in connection with other information — including a personal identification number — allows for the identification or identifiability of a natural person.
-
-#### Usage Data
-Information collected automatically through this Website (or third-party services employed in this Website), which can include: the IP addresses or domain names of the computers utilized by the Users who use this Website, the URI addresses (Uniform Resource Identifier), the time of the request, the method utilized to submit the request to the server, the size of the file received in response, the numerical code indicating the status of the server's answer (successful outcome, error, etc.), the country of origin, the features of the browser and the operating system utilized by the User, the various time details per visit (e.g., the time spent on each page within the Application) and the details about the path followed within the Application with special reference to the sequence of pages visited, and other parameters about the device operating system and/or the User's IT environment.
-
-#### User
-The individual using this Website who, unless otherwise specified, coincides with the Data Subject.
-
-#### Data Subject
-The natural person to whom the Personal Data refers.
-
-#### Data Processor (or Data Supervisor)
-The natural or legal person, public authority, agency or other body which processes Personal Data on behalf of the Controller, as described in this privacy policy.
-
-#### Data Controller (or Owner)
-The natural or legal person, public authority, agency or other body which, alone or jointly with others, determines the purposes and means of the processing of Personal Data, including the security measures concerning the operation and use of this Website. The Data Controller, unless otherwise specified, is the Owner of this Website.
-
-#### This Website (or this Application)
-The means by which the Personal Data of the User is collected and processed.
-
-#### Service
-The service provided by this Website as described in the relative terms (if available) and on this site/application.
-
-#### European Union (or EU)
-Unless otherwise specified, all references made within this document to the European Union include all current member states to the European Union and the European Economic Area.
-
-#### Cookies
-Small sets of data stored in the User's device.
-
-#### Legal information
-This privacy statement has been prepared based on provisions of multiple legislations, including Art. 13/14 of Regulation (EU) 2016/679 (General Data Protection Regulation).
-
-This privacy policy relates solely to this Website, if not stated otherwise within this document.
+Sie haben zudem das Recht, sich bei einer Datenschutz-Aufsichtsbehörde zu beschweren. Die zuständige Aufsichtsbehörde für Baden-Württemberg ist der Landesbeauftragte für den Datenschutz und die Informationsfreiheit Baden-Württemberg (LfDI BW): [https://www.baden-wuerttemberg.datenschutz.de](https://www.baden-wuerttemberg.datenschutz.de)


### PR DESCRIPTION
**Impressum:**
- Remove phone number (email alone satisfies § 5 TMG)
- Remove redundant "Vertreten durch" section (only needed for companies)
- Add ODR platform link (required by EU regulation since 2016)

**Privacy policy:**
- Full rewrite in German (DSGVO requires the language of your audience)
- Replace invalidated Privacy Shield reference with Standard Contractual Clauses (SCCs) for GitHub and Cloudflare
- Strip boilerplate clauses about contracts, sales, and marketing that don't apply to a personal blog
- Remove deprecated "Do Not Track" section
- Add competent supervisory authority (LfDI Baden-Württemberg)
- Add last-updated date
- Update footer link label from "Privacy" to "Datenschutz"